### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-Flask==2.0.2
+Flask==2.2.2
 gunicorn
+Werkzeug==2.2.2


### PR DESCRIPTION
This sample is currently breaking our quickstart. This is a version bump and adding Werkzeug==2.2.2 to fix the sample.