### PR TITLE
Fix werkzeug / flask version incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-Flask==2.0.2
+Flask==2.2.2
+Werkzeug==2.3.7
 gunicorn


### PR DESCRIPTION
## Purpose
Flask 2.0.2 isn't compatible with the latest werkzeug version, causing a startup error. Changed flask version to 2.2.2 and added explicit requirement of werkzeug for 2.3.7.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?
Changed flask version to 2.2.2 and added explicit requirement of werkzeug for 2.3.7.

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->